### PR TITLE
feat(automerge): add --automerge-retry-count to retry transient merge…

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -53,6 +53,7 @@ const (
 	AutoDiscoverModeFlag             = "autodiscover-mode"
 	AutomergeFlag                    = "automerge"
 	AutomergeMethodFlag              = "automerge-method"
+	AutomergeRetryCountFlag          = "automerge-retry-count"
 	ParallelPlanFlag                 = "parallel-plan"
 	ParallelApplyFlag                = "parallel-apply"
 	AutoplanModules                  = "autoplan-modules"
@@ -697,6 +698,13 @@ var boolFlags = map[string]boolFlag{
 	},
 }
 var intFlags = map[string]intFlag{
+	AutomergeRetryCountFlag: {
+		description: fmt.Sprintf("Number of times to retry merging a pull request when automerge (--%s) is enabled and the merge fails. "+
+			"Retries use an exponential backoff and help work around transient VCS errors, such as GitHub branch protection or "+
+			"repository rulesets briefly reporting required status checks as pending right after Atlantis applies. "+
+			"Defaults to 0, which attempts the merge exactly once.", AutomergeFlag),
+		defaultValue: 0,
+	},
 	CheckoutDepthFlag: {
 		description: fmt.Sprintf("Used only if --%s=%s.", CheckoutStrategyFlag, CheckoutStrategyMerge) +
 			" How many commits to include in each of base and feature branches when cloning repository." +

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -63,6 +63,7 @@ var testFlags = map[string]any{
 	AutoDiscoverModeFlag:             "auto",
 	AutomergeFlag:                    true,
 	AutomergeMethodFlag:              "squash",
+	AutomergeRetryCountFlag:          3,
 	AutoplanFileListFlag:             "**/*.tf,**/*.yml",
 	BitbucketApiUserFlag:             "bitbucket-api-user",
 	BitbucketBaseURLFlag:             "https://bitbucket-base-url.com",

--- a/runatlantis.io/docs/automerging.md
+++ b/runatlantis.io/docs/automerging.md
@@ -54,6 +54,25 @@ The `method` must be one of:
 
 This is currently only implemented for the GitHub VCS.
 
+## How to retry a failed automerge
+
+Some VCS providers can briefly reject a merge right after Atlantis applies. With
+GitHub branch protection or repository rulesets, the required status checks
+(including `atlantis/apply`) are not always registered as passing by the time
+Atlantis calls the merge API, so the merge fails with an error such as
+`required status checks are expected`. These failures are transient and clear
+within a few seconds.
+
+Set the `--automerge-retry-count` server flag (or `ATLANTIS_AUTOMERGE_RETRY_COUNT`
+environment variable) to retry the merge, with an exponential backoff, before
+giving up.
+
+```shell
+atlantis server --automerge-retry-count 3
+```
+
+Defaults to `0`, which attempts the merge exactly once.
+
 ## Requirements
 
 ### All Plans Must Succeed

--- a/runatlantis.io/docs/server-configuration.md
+++ b/runatlantis.io/docs/server-configuration.md
@@ -165,6 +165,20 @@ Default merge method to use when automerging pull requests. Valid values are
 method is used. This can be overridden per command with the `--auto-merge-method`
 comment flag. Currently only implemented for GitHub.
 
+### `--automerge-retry-count`
+
+```bash
+atlantis server --automerge-retry-count=3
+# or
+ATLANTIS_AUTOMERGE_RETRY_COUNT=3
+```
+
+Number of times to retry merging a pull request when `--automerge` is enabled and
+the merge fails. Retries use an exponential backoff and help work around transient
+VCS errors, such as GitHub branch protection or repository rulesets briefly
+reporting required status checks as pending immediately after Atlantis applies.
+Defaults to `0`, which attempts the merge exactly once.
+
 ### `--autoplan-file-list` <Badge text="v0.15.0+" type="info"/>
 
 ```bash

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -85,7 +85,11 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 // AutomergeRetryCount is 0 (the default) the merge is attempted exactly once and
 // this behaves identically to a single MergePull call.
 func (c *AutoMerger) mergeWithRetry(ctx *command.Context, pullOptions models.PullRequestOptions) error {
-	maxAttempts := c.AutomergeRetryCount + 1
+	retryCount := c.AutomergeRetryCount
+	if retryCount < 0 {
+		retryCount = 0
+	}
+	maxAttempts := retryCount + 1
 	var err error
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		if err = c.VCSClient.MergePull(ctx.Log, ctx.Pull, pullOptions); err == nil {

--- a/server/events/automerger.go
+++ b/server/events/automerger.go
@@ -5,16 +5,34 @@ package events
 
 import (
 	"fmt"
+	"math/rand/v2"
+	"time"
 
 	"github.com/runatlantis/atlantis/server/events/command"
 	"github.com/runatlantis/atlantis/server/events/models"
 	"github.com/runatlantis/atlantis/server/events/vcs"
 )
 
+// Default backoff bounds used between automerge retries when the AutoMerger
+// does not override them (see retryBackoffMin/retryBackoffMax).
+const (
+	defaultAutomergeRetryMinBackoff = 2 * time.Second
+	defaultAutomergeRetryMaxBackoff = 30 * time.Second
+)
+
 type AutoMerger struct {
 	VCSClient             vcs.Client
 	GlobalAutomerge       bool
 	GlobalAutomergeMethod string
+	// AutomergeRetryCount is the number of additional times a failed merge is
+	// retried before giving up. Zero (the default) means the merge is attempted
+	// exactly once, preserving the original behavior.
+	AutomergeRetryCount int
+	// retryBackoffMin and retryBackoffMax bound the wait between merge retries.
+	// When zero the defaults above are used; they exist mainly so tests can use
+	// short waits.
+	retryBackoffMin time.Duration
+	retryBackoffMax time.Duration
 }
 
 func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatus, deleteSourceBranchOnMerge bool, mergeMethod string) {
@@ -38,12 +56,12 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 		mergeMethod = c.GlobalAutomergeMethod
 	}
 
-	// Make the API call to perform the merge.
+	// Make the API call to perform the merge, retrying on failure if configured.
 	ctx.Log.Info("automerging pull request")
 	var pullOptions models.PullRequestOptions
 	pullOptions.DeleteSourceBranchOnMerge = deleteSourceBranchOnMerge
 	pullOptions.MergeMethod = mergeMethod
-	err := c.VCSClient.MergePull(ctx.Log, ctx.Pull, pullOptions)
+	err := c.mergeWithRetry(ctx, pullOptions)
 
 	if err != nil {
 		ctx.Log.Err("automerging failed: %s", err)
@@ -53,6 +71,73 @@ func (c *AutoMerger) automerge(ctx *command.Context, pullStatus models.PullStatu
 			ctx.Log.Err("failed to comment about automerge failing: %s", err)
 		}
 	}
+}
+
+// mergeWithRetry attempts to merge the pull request, retrying up to
+// AutomergeRetryCount additional times on failure with an exponential backoff.
+//
+// Some VCS providers can briefly report a pull request as unmergeable right
+// after Atlantis sets its apply commit status to success: with GitHub branch
+// protection or repository rulesets the required status checks have not always
+// propagated by the time the merge API call is made, so the merge is rejected
+// (e.g. "required status checks are expected"). Such failures are transient and
+// clear within a few seconds, so retrying works around them. When
+// AutomergeRetryCount is 0 (the default) the merge is attempted exactly once and
+// this behaves identically to a single MergePull call.
+func (c *AutoMerger) mergeWithRetry(ctx *command.Context, pullOptions models.PullRequestOptions) error {
+	maxAttempts := c.AutomergeRetryCount + 1
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if err = c.VCSClient.MergePull(ctx.Log, ctx.Pull, pullOptions); err == nil {
+			return nil
+		}
+		if attempt == maxAttempts {
+			break
+		}
+		sleep := c.retryBackoff(attempt)
+		ctx.Log.Warn("automerge attempt %d/%d failed: %s; retrying in %s", attempt, maxAttempts, err, sleep)
+		time.Sleep(sleep)
+	}
+	return err
+}
+
+// retryBackoff returns how long to wait before the given 1-indexed retry
+// attempt. The delay starts at the minimum bound, doubles with each attempt,
+// and is capped at the maximum bound. Full jitter is then applied (a random
+// duration in [min, delay]) so repeated retries don't fire in lockstep.
+func (c *AutoMerger) retryBackoff(attempt int) time.Duration {
+	minBackoff, maxBackoff := c.backoffBounds()
+
+	delay := minBackoff
+	for i := 1; i < attempt && delay < maxBackoff; i++ {
+		delay *= 2
+	}
+	if delay > maxBackoff {
+		delay = maxBackoff
+	}
+
+	if delay > minBackoff {
+		delay = minBackoff + rand.N(delay-minBackoff+1)
+	}
+	return delay
+}
+
+// backoffBounds returns the min and max wait between merge retries, applying
+// the package defaults when the (test-only) overrides are unset and ensuring
+// max is never below min.
+func (c *AutoMerger) backoffBounds() (time.Duration, time.Duration) {
+	minBackoff := c.retryBackoffMin
+	if minBackoff <= 0 {
+		minBackoff = defaultAutomergeRetryMinBackoff
+	}
+	maxBackoff := c.retryBackoffMax
+	if maxBackoff <= 0 {
+		maxBackoff = defaultAutomergeRetryMaxBackoff
+	}
+	if maxBackoff < minBackoff {
+		maxBackoff = minBackoff
+	}
+	return minBackoff, maxBackoff
 }
 
 // automergeEnabled returns true if automerging is enabled in this context.

--- a/server/events/automerger_internal_test.go
+++ b/server/events/automerger_internal_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 The Atlantis Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package events
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/petergtz/pegomock/v4"
+	"github.com/runatlantis/atlantis/server/events/command"
+	"github.com/runatlantis/atlantis/server/events/models"
+	vcsmocks "github.com/runatlantis/atlantis/server/events/vcs/mocks"
+	"github.com/runatlantis/atlantis/server/logging"
+)
+
+// newAutomergeTestContext returns a command.Context sufficient for exercising
+// AutoMerger.automerge with a pull request that has a single applied project.
+func newAutomergeTestContext(t *testing.T) (*command.Context, models.PullStatus) {
+	ctx := &command.Context{
+		Log: logging.NewNoopLogger(t),
+		Pull: models.PullRequest{
+			Num:      1,
+			BaseRepo: models.Repo{FullName: "owner/repo"},
+		},
+	}
+	pullStatus := models.PullStatus{
+		Projects: []models.ProjectStatus{
+			{RepoRelDir: ".", Workspace: "default", Status: models.AppliedPlanStatus},
+		},
+	}
+	return ctx, pullStatus
+}
+
+// fastRetryAutoMerger builds an AutoMerger with negligible backoff so retry
+// tests don't sleep for whole seconds.
+func fastRetryAutoMerger(vcsClient *vcsmocks.MockClient, retryCount int) *AutoMerger {
+	return &AutoMerger{
+		VCSClient:           vcsClient,
+		AutomergeRetryCount: retryCount,
+		retryBackoffMin:     time.Millisecond,
+		retryBackoffMax:     time.Millisecond,
+	}
+}
+
+func anyMergePullArgs() (logging.SimpleLogging, models.PullRequest, models.PullRequestOptions) {
+	return Any[logging.SimpleLogging](), Any[models.PullRequest](), Any[models.PullRequestOptions]()
+}
+
+// TestAutoMerger_automerge_RetriesUntilSuccess verifies that a transient merge
+// failure is retried and, once the merge succeeds, no failure comment is posted.
+func TestAutoMerger_automerge_RetriesUntilSuccess(t *testing.T) {
+	RegisterMockTestingT(t)
+	vcsClient := vcsmocks.NewMockClient()
+	// Fail twice, then succeed on the third attempt.
+	When(vcsClient.MergePull(anyMergePullArgs())).
+		ThenReturn(errors.New("required status checks are expected")).
+		ThenReturn(errors.New("required status checks are expected")).
+		ThenReturn(nil)
+
+	am := fastRetryAutoMerger(vcsClient, 3)
+	ctx, pullStatus := newAutomergeTestContext(t)
+
+	am.automerge(ctx, pullStatus, false, "")
+
+	l, p, o := anyMergePullArgs()
+	vcsClient.VerifyWasCalled(Times(3)).MergePull(l, p, o)
+	// Only the initial "automerging" comment should be posted, not a failure one.
+	cl, cr, cn, cc, ck := anyCreateCommentArgs()
+	vcsClient.VerifyWasCalled(Once()).CreateComment(cl, cr, cn, cc, ck)
+}
+
+// TestAutoMerger_automerge_RetriesExhausted verifies that once retries are
+// exhausted a failure comment is posted and MergePull is called exactly
+// AutomergeRetryCount+1 times.
+func TestAutoMerger_automerge_RetriesExhausted(t *testing.T) {
+	RegisterMockTestingT(t)
+	vcsClient := vcsmocks.NewMockClient()
+	When(vcsClient.MergePull(anyMergePullArgs())).ThenReturn(errors.New("boom"))
+
+	am := fastRetryAutoMerger(vcsClient, 2)
+	ctx, pullStatus := newAutomergeTestContext(t)
+
+	am.automerge(ctx, pullStatus, false, "")
+
+	l, p, o := anyMergePullArgs()
+	vcsClient.VerifyWasCalled(Times(3)).MergePull(l, p, o)
+	// Initial "automerging" comment plus a failure comment.
+	cl, cr, cn, cc, ck := anyCreateCommentArgs()
+	vcsClient.VerifyWasCalled(Times(2)).CreateComment(cl, cr, cn, cc, ck)
+}
+
+// TestAutoMerger_automerge_NoRetryByDefault verifies that with the default
+// retry count of 0 the merge is attempted exactly once, preserving the original
+// behavior.
+func TestAutoMerger_automerge_NoRetryByDefault(t *testing.T) {
+	RegisterMockTestingT(t)
+	vcsClient := vcsmocks.NewMockClient()
+	When(vcsClient.MergePull(anyMergePullArgs())).ThenReturn(errors.New("boom"))
+
+	am := &AutoMerger{VCSClient: vcsClient}
+	ctx, pullStatus := newAutomergeTestContext(t)
+
+	am.automerge(ctx, pullStatus, false, "")
+
+	l, p, o := anyMergePullArgs()
+	vcsClient.VerifyWasCalled(Once()).MergePull(l, p, o)
+}
+
+func anyCreateCommentArgs() (logging.SimpleLogging, models.Repo, int, string, string) {
+	return Any[logging.SimpleLogging](), Any[models.Repo](), Any[int](), Any[string](), Any[string]()
+}
+
+// TestAutoMerger_retryBackoff verifies the delay grows exponentially, stays
+// within [min, cap] once jitter is applied, and never exceeds the maximum.
+func TestAutoMerger_retryBackoff(t *testing.T) {
+	am := &AutoMerger{
+		retryBackoffMin: 2 * time.Second,
+		retryBackoffMax: 30 * time.Second,
+	}
+
+	// Uncapped exponential ceilings per attempt: 2s, 4s, 8s, ... capped at 30s.
+	caps := map[int]time.Duration{
+		1: 2 * time.Second,
+		2: 4 * time.Second,
+		3: 8 * time.Second,
+		4: 16 * time.Second,
+		5: 30 * time.Second,
+		6: 30 * time.Second,
+	}
+	// Sample repeatedly since jitter is random.
+	for attempt, ceiling := range caps {
+		for range 100 {
+			got := am.retryBackoff(attempt)
+			if got < am.retryBackoffMin {
+				t.Fatalf("attempt %d: backoff %s below min %s", attempt, got, am.retryBackoffMin)
+			}
+			if got > ceiling {
+				t.Fatalf("attempt %d: backoff %s above expected ceiling %s", attempt, got, ceiling)
+			}
+		}
+	}
+}
+
+// TestAutoMerger_retryBackoff_Defaults verifies the package defaults are used
+// when no overrides are set and that a min greater than max is clamped.
+func TestAutoMerger_retryBackoff_Defaults(t *testing.T) {
+	am := &AutoMerger{}
+	if got := am.retryBackoff(1); got != defaultAutomergeRetryMinBackoff {
+		t.Fatalf("expected first backoff to equal default min %s, got %s", defaultAutomergeRetryMinBackoff, got)
+	}
+
+	// max below min should be clamped up to min, yielding a fixed delay.
+	clamped := &AutoMerger{retryBackoffMin: 5 * time.Second, retryBackoffMax: time.Second}
+	if got := clamped.retryBackoff(3); got != 5*time.Second {
+		t.Fatalf("expected clamped backoff of 5s, got %s", got)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -798,6 +798,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 		VCSClient:             vcsClient,
 		GlobalAutomerge:       userConfig.Automerge,
 		GlobalAutomergeMethod: userConfig.AutomergeMethod,
+		AutomergeRetryCount:   userConfig.AutomergeRetryCount,
 	}
 
 	projectOutputWrapper := &events.ProjectOutputWrapper{

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -24,6 +24,7 @@ type UserConfig struct {
 	AutoDiscoverModeFlag        string `mapstructure:"autodiscover-mode"`
 	Automerge                   bool   `mapstructure:"automerge"`
 	AutomergeMethod             string `mapstructure:"automerge-method"`
+	AutomergeRetryCount         int    `mapstructure:"automerge-retry-count"`
 	AutoplanFileList            string `mapstructure:"autoplan-file-list"`
 	AutoplanModules             bool   `mapstructure:"autoplan-modules"`
 	AutoplanModulesFromProjects string `mapstructure:"autoplan-modules-from-projects"`


### PR DESCRIPTION
… failures

When automerge is enabled, Atlantis calls the VCS merge API immediately after setting its apply commit status to success. With GitHub branch protection or repository rulesets, the required status checks (including atlantis/apply) are not always registered as passing by the time the merge is attempted, so the merge is rejected (e.g. "required status checks are expected") even though the apply succeeded. These failures are transient and clear within a few seconds.

Add an opt-in --automerge-retry-count server flag that retries the merge with an exponential backoff before giving up. Defaults to 0, which attempts the merge exactly once and preserves the existing behavior.

Fixes #5967

## what

* Adding retries to the automerge feature to cope with GitHub API eventual consistency
* Added autoback off logic to Atlantis


## why

* Was hitting an issue where because Atlantis Apply was part of the list of merge checks the automerge would randomly fail because the API had not yet fully updated to the Apply check having passed. This also helps with random GitHub API failures.

* Adding retry logic as the current backoff dependency used in the GitLab handler seems to be unmaintained. I would be happy to switch to using this if you would prefer but I recommend we switch over to using code maintained in Atlantis and drop the dependency.

## tests

* Tests have been added for the changes.

## references

#5967

